### PR TITLE
Fix wrong logic in process deps to add to

### DIFF
--- a/LibFindMacros.cmake
+++ b/LibFindMacros.cmake
@@ -1,4 +1,4 @@
-# Version 2.3
+# Version 2.4
 # Public Domain, originally written by Lasse Kärkkäinen <tronic>
 # Maintained at https://github.com/Tronic/cmake-modules
 # Please send your improvements as pull requests on Github.
@@ -129,24 +129,39 @@ function (libfind_process PREFIX)
 
   # Process deps to add to
   foreach (i ${PREFIX} ${${PREFIX}_DEPENDENCIES})
-    if (DEFINED ${i}_INCLUDE_OPTS OR DEFINED ${i}_LIBRARY_OPTS)
+    if (DEFINED ${i}_INCLUDE_OPTS)
       # The package seems to export option lists that we can use, woohoo!
       list(APPEND includeopts ${${i}_INCLUDE_OPTS})
-      list(APPEND libraryopts ${${i}_LIBRARY_OPTS})
     else()
-      # If plural forms don't exist or they equal singular forms
-      if ((NOT DEFINED ${i}_INCLUDE_DIRS AND NOT DEFINED ${i}_LIBRARIES) OR
-          (${i}_INCLUDE_DIR STREQUAL ${i}_INCLUDE_DIRS AND ${i}_LIBRARY STREQUAL ${i}_LIBRARIES))
+      if (DEFINED ${i}_INCLUDE_DIR)
         # Singular forms can be used
-        if (DEFINED ${i}_INCLUDE_DIR)
-          list(APPEND includeopts ${i}_INCLUDE_DIR)
-        endif()
-        if (DEFINED ${i}_LIBRARY)
-          list(APPEND libraryopts ${i}_LIBRARY)
-        endif()
+        list(APPEND includeopts ${i}_INCLUDE_DIR)
       else()
-        # Oh no, we don't know the option names
-        message(FATAL_ERROR "We couldn't determine config variable names for ${i} includes and libs. Aieeh!")
+        if (DEFINED ${i}_INCLUDE_DIRS)
+          # Plural forms can be used
+          list(APPEND includeopts ${i}_INCLUDE_DIRS)
+        else()
+          # Oh no, we don't know the option names
+          message(FATAL_ERROR "We couldn't determine config variable names for ${i} includes. Aieeh!")
+        endif()
+      endif()
+    endif()
+
+    if (DEFINED ${i}_LIBRARY_OPTS)
+      # The package seems to export option lists that we can use, woohoo!
+      list(APPEND includeopts ${${i}_LIBRARY_OPTS})
+    else()
+      if (DEFINED ${i}_LIBRARY)
+        # Singular forms can be used
+        list(APPEND includeopts ${i}_LIBRARY)
+      else()
+        if (DEFINED ${i}_LIBRARIES)
+          # Plural forms can be used
+          list(APPEND includeopts ${i}_LIBRARIES)
+        else()
+          # Oh no, we don't know the option names
+          message(FATAL_ERROR "We couldn't determine config variable names for ${i} libraries. Aieeh!")
+        endif()
       endif()
     endif()
   endforeach()


### PR DESCRIPTION
Separate the include and lib check, and don't verify if plural form equals singular as there might be a case where both are defined. The expected behavior is to disregard the plural form and consider only the singular.